### PR TITLE
SSCAE-4693 [APP][体能数据] - 球队平均值计算应包含数据为0的球员

### DIFF
--- a/src/AdvancedColorList.js
+++ b/src/AdvancedColorList.js
@@ -250,7 +250,7 @@ export default class AdvancedColorList extends React.Component {
                     let maxLengthValue = maxBy(playerData, (playerItem) => {
                         return playerItem[colId] ? playerItem[colId].length : 0;
                     });
-                    let meanValue = meanBy(filter(playerData, (playerItem) => toInteger(playerItem[colId]) !== 0), (playerItem) => {
+                    let meanValue = meanBy(playerData, (playerItem) => {
                         return toInteger(playerItem[colId]);
                     });
                     let maxValue = maxBy(playerData, (playerItem) => {


### PR DESCRIPTION
SSCAE-4691
[APP][体能数据] - 体能数据全部为0的体能参数球队平均值显示为NaN